### PR TITLE
Replace pymatgen substitution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.22.0
-ase==3.21.1
-pymatgen==2022.0.17
+numpy==1.22.3
+ase==3.22.1
+pymatgen==2022.3.29
 fire==0.4.0

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(
     ],
     package_dir={"": "src"},
     packages=find_packages(where="src"),
-    install_requires=["numpy<=1.22.0", "ase", "pymatgen<=2022.0.17", "fire",],
+    install_requires=["numpy", "ase", "pymatgen", "fire",],
     include_package_data=True,
 )

--- a/src/autocat/saa.py
+++ b/src/autocat/saa.py
@@ -9,7 +9,6 @@ from ase import Atoms
 from ase.data import atomic_numbers
 from ase.data import ground_state_magnetic_moments
 from pymatgen.io.ase import AseAtomsAdaptor
-from pymatgen.analysis.adsorption import AdsorbateSiteFinder
 from pymatgen.analysis.structure_matcher import StructureMatcher
 from autocat.surface import generate_surface_structures
 

--- a/src/autocat/saa.py
+++ b/src/autocat/saa.py
@@ -34,11 +34,9 @@ def _find_dopant_index(structure, dopant_element):
     return dopant_index[0][0]
 
 
-def _find_all_surface_atom_indices(structure, tol=None) -> List[int]:
+def _find_all_surface_atom_indices(structure, tol: float = 0.5) -> List[int]:
     """Helper function to find all surface atom indices
     within a tolerance distance of the highest atom"""
-    if tol is None:
-        tol = 0.5
     all_heights = structure.positions[:, 2]
     highest_atom_idx = np.argmax(all_heights)
     height_of_highest_atom = structure[highest_atom_idx].z

--- a/tests/test_saa.py
+++ b/tests/test_saa.py
@@ -10,6 +10,7 @@ import numpy as np
 from autocat.saa import generate_saa_structures
 from autocat.saa import substitute_single_atom_on_surface
 from autocat.saa import _find_dopant_index
+from autocat.saa import _find_all_surface_atom_indices
 from autocat.saa import AutocatSaaGenerationError
 from autocat.surface import generate_surface_structures
 
@@ -128,3 +129,31 @@ def test_find_dopant_index():
     host[32].symbol = "Au"
     with raises(NotImplementedError):
         _find_dopant_index(host, "Au")
+
+
+def test_find_all_surface_atom_indices():
+    # Test helper function for finding all surface atoms
+    # clean elemental surface
+    ru = generate_surface_structures(["Ru"], supercell_dim=(2, 2, 4))["Ru"]["hcp0001"][
+        "structure"
+    ]
+    indices = _find_all_surface_atom_indices(ru)
+    assert indices == [12, 13, 14, 15]
+
+    pt110 = generate_surface_structures(["Pt"], supercell_dim=(1, 1, 4))["Pt"][
+        "fcc110"
+    ]["structure"]
+    indices = _find_all_surface_atom_indices(pt110)
+    assert indices == [3]
+
+    # check increasing tolerance
+    indices = _find_all_surface_atom_indices(pt110, tol=1.4)
+    assert indices == [2, 3]
+
+    pt100 = generate_surface_structures(["Pt"], supercell_dim=(3, 3, 4))["Pt"][
+        "fcc100"
+    ]["structure"]
+    pt100[27].z += 0.3
+    pt100[30].z -= 0.4
+    indices = _find_all_surface_atom_indices(pt100, tol=0.6)
+    assert indices == [27, 28, 29, 31, 32, 33, 34, 35]


### PR DESCRIPTION
This PR replaces the pymatgen doping to address #24.

The substitution step is now done manipulating the `Atoms` object where `pymatgen` is 
used to ensure that only a single unique site to dope is present.