### PR TITLE
Rotate NH and OH defaults

### DIFF
--- a/src/autocat/data/intermediates/nrr.py
+++ b/src/autocat/data/intermediates/nrr.py
@@ -5,7 +5,7 @@ NRR_INTERMEDIATE_NAMES = ["NNH", "NNH2", "N", "NH", "NH2", "NHNH", "NHNH2", "NH2
 # N is in atomic symbols and NH2 is in g2
 NRR_MOLS = {
     "NNH": Atoms("N2H", [(0.0, 0.0, 0.0), (-0.2, 0.0, 1.2), (0.51, 0, 1.91)]),
-    "NH": Atoms("NH", [(0.0, 0.0, 0.0), (0.0, 0.0, 1.0)]),
+    "NH": Atoms("NH", [(0.0, 0.0, 0.0), (0.71, 0.0, 0.71)]),
     "NH2": Atoms(
         "NH2",
         [

--- a/src/autocat/data/intermediates/orr.py
+++ b/src/autocat/data/intermediates/orr.py
@@ -5,5 +5,5 @@ ORR_INTERMEDIATE_NAMES = ["OOH", "O", "OH"]
 # O is in atomic symbols
 ORR_MOLS = {
     "OOH": Atoms("O2H", [(0.0, 0.0, 0.0), (0.0, 1.2, 0.8), (0.0, 0.8, 1.6)]),
-    "OH": Atoms("OH", [(0.0, 0.0, 0.0), (0.0, 0.0, 0.97)]),
+    "OH": Atoms("OH", [(0.0, 0.0, 0.0), (0.69, 0.0, 0.69)]),
 }

--- a/tests/test_adsorption.py
+++ b/tests/test_adsorption.py
@@ -33,7 +33,7 @@ def test_generate_molecule_from_name():
     assert mol["structure"].positions[0] == approx([7.345, 7.5, 6.545])
     # ORR intermediate
     mol = generate_molecule(molecule_name="OH")
-    assert mol["structure"].positions[1][2] == approx(7.985)
+    assert mol["structure"].positions[1][2] == approx(7.845)
     # atom-in-a-box
     mol = generate_molecule(molecule_name="Cl")
     assert len(mol["structure"]) == 1


### PR DESCRIPTION
Previously the defaults for `OH` and `NH` were perfectly vertical. 

To be more general, we have rotated each of these 45deg.